### PR TITLE
feat: add in rankings query to page / user api

### DIFF
--- a/prisma/migrations/20241005024637_create_rankings/migration.sql
+++ b/prisma/migrations/20241005024637_create_rankings/migration.sql
@@ -1,0 +1,29 @@
+-- CreateEnum
+CREATE TYPE "Tier" AS ENUM ('SS', 'S', 'A', 'B', 'C', 'D');
+
+-- CreateEnum
+CREATE TYPE "Difficulty" AS ENUM ('Normal', 'Hard', 'VeryHard', 'Hardcore', 'Extreme', 'Insane', 'Torment', 'Floor1_49', 'Floor50_125');
+
+-- CreateEnum
+CREATE TYPE "ArmorType" AS ENUM ('Normal', 'LightArmor', 'HeavyArmor', 'Unarmed', 'ElasticArmor');
+
+-- CreateTable
+CREATE TABLE "rankings" (
+    "id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "raid_id" TEXT NOT NULL,
+    "armor_type" "ArmorType" NOT NULL,
+    "difficulty" "Difficulty" NOT NULL,
+    "student_id" TEXT NOT NULL,
+    "tier" "Tier" NOT NULL,
+    "user_id" TEXT NOT NULL,
+
+    CONSTRAINT "rankings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "rankings_raid_id_armor_type_difficulty_student_id_user_id_key" ON "rankings"("raid_id", "armor_type", "difficulty", "student_id", "user_id");
+
+-- AddForeignKey
+ALTER TABLE "rankings" ADD CONSTRAINT "rankings_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,7 @@ model User {
   image         String?
   accounts      Account[]
   sessions      Session[]
+  Ranking       Ranking[]
 
   @@map("users")
 }
@@ -56,4 +57,54 @@ model VerificationToken {
 
   @@unique([identifier, token])
   @@map("verification_tokens")
+}
+
+model Ranking {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  // Category fields
+  raidId     String     @map("raid_id")
+  armorType  ArmorType  @map("armor_type")
+  difficulty Difficulty
+
+  // Ranking fields
+  studentId String @map("student_id")
+  tier      Tier
+  user      User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String @map("user_id")
+
+  // Users can only vote for each student once per category
+  @@unique([raidId, armorType, difficulty, studentId, userId])
+  @@map("rankings")
+}
+
+enum Tier {
+  SS
+  S
+  A
+  B
+  C
+  D
+}
+
+enum Difficulty {
+  Normal
+  Hard
+  VeryHard
+  Hardcore
+  Extreme
+  Insane
+  Torment
+  Floor1_49
+  Floor50_125
+}
+
+enum ArmorType {
+  Normal
+  LightArmor
+  HeavyArmor
+  Unarmed
+  ElasticArmor
 }

--- a/src/app/api/rankings/[userId]/route.ts
+++ b/src/app/api/rankings/[userId]/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { fetchDataForUser } from '@/lib/rankings'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { userId: string } }
+) {
+  const { userId } = params
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: 'Invalid or missing userId' },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const data = await fetchDataForUser(userId)
+    return NextResponse.json(data, { status: 200 })
+  } catch (error) {
+    console.error('Error fetching rankings:', error)
+    return NextResponse.json(
+      { error: 'An error occurred while fetching rankings' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,14 @@
 import React from 'react'
 import fetchData from '@/lib/shaleDb'
 import TierList from '@/components/TierList/TierList'
+import { fetchGlobalRankings } from '@/lib/rankings'
 
 export const revalidate = 600 // invalidate every 5 minutes
 
 const Home = async () => {
   const data = await fetchData()
-  return <TierList data={data} />
+  const rankings = await fetchGlobalRankings()
+  return <TierList data={data} rankings={rankings} />
 }
 
 export default Home

--- a/src/components/TierList/TierList.tsx
+++ b/src/components/TierList/TierList.tsx
@@ -15,12 +15,14 @@ import { FilterActionTypes, initialState, reducer } from '@/state/FilterState'
 import ArmorButton from '@/components/TierList/ArmorButton'
 import RaidCard from '@/components/Raids/RaidCard'
 import AuthComponent from '@/components/Auth/AuthComponent'
+import { Ranking } from '@/lib/rankings'
 
 type TierListProps = {
   data: SchaleDBData
+  rankings: Ranking[]
 }
 
-export default function TierList({ data }: TierListProps) {
+export default function TierList({ data, rankings }: TierListProps) {
   const { raids, students } = data
 
   // Use useReducer for state management
@@ -48,6 +50,12 @@ export default function TierList({ data }: TierListProps) {
     // You can update your state here to reflect the new tier placement
     // For example, move the student between lists
   }
+
+  // Current rankings
+  // @TODO: Actually sort students based on rankings
+  console.log(rankings)
+
+  // @TODO: Add useEffect to query my own rankings (using /api/rankings/[userId])
 
   const selectedRaid = raids.find((raid) => raid.Id === state.raid)
 

--- a/src/components/TierList/TierList.tsx
+++ b/src/components/TierList/TierList.tsx
@@ -4,10 +4,8 @@ import React, { useReducer } from 'react'
 import {
   DragDropContext,
   Draggable,
-  DraggingStyle,
   Droppable,
   DropResult,
-  NotDraggingStyle,
 } from '@hello-pangea/dnd'
 import { SchaleDBData, Student } from '@/lib/shaleDbTypes'
 import { AllTiers, SquadTypes } from '@/lib/tiers'

--- a/src/lib/authoptions.ts
+++ b/src/lib/authoptions.ts
@@ -1,9 +1,7 @@
 import type { AuthOptions } from 'next-auth'
 import { PrismaAdapter } from '@next-auth/prisma-adapter'
 import DiscordProvider from 'next-auth/providers/discord'
-import { PrismaClient } from '@prisma/client'
-
-const prisma = new PrismaClient()
+import prisma from '@/lib/prisma'
 
 export const authOptions: AuthOptions = {
   adapter: PrismaAdapter(prisma),

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export default prisma

--- a/src/lib/rankings.ts
+++ b/src/lib/rankings.ts
@@ -1,0 +1,39 @@
+import prisma from '@/lib/prisma'
+import { ArmorType, Difficulty } from '@/lib/shaleDbTypes'
+import { Tier } from '@/lib/tiers' // Adjust the path based on your setup
+
+export type Ranking = {
+  raidId: string
+  armorType: ArmorType
+  difficulty: Difficulty
+  studentId: string
+  tier: Tier
+}
+
+// Function to fetch tier data grouped by raidId, armorType, difficulty, and studentId
+export const fetchGlobalRankings = async (): Promise<Ranking[]> => {
+  return prisma.$queryRaw<Ranking[]>`
+    SELECT
+      "raidId",
+      "armorType",
+      "difficulty",
+      "studentId",
+      MODE() WITHIN GROUP (ORDER BY "tier") AS "tier"
+    FROM "rankings"
+    GROUP BY "raidId", "armorType", "difficulty", "studentId"
+  `
+}
+
+// Function to fetch grouped tier data for a specific userId
+export const fetchDataForUser = async (userId: string): Promise<Ranking[]> => {
+  return prisma.$queryRaw<Ranking[]>`
+    SELECT
+      "raidId",
+      "armorType",
+      "difficulty",
+      "studentId",
+      "tier"
+    FROM "rankings"
+    WHERE "userId" = ${userId}
+  `
+}

--- a/src/lib/rankings.ts
+++ b/src/lib/rankings.ts
@@ -14,13 +14,13 @@ export type Ranking = {
 export const fetchGlobalRankings = async (): Promise<Ranking[]> => {
   return prisma.$queryRaw<Ranking[]>`
     SELECT
-      "raidId",
-      "armorType",
+      "raid_id" AS "raidId",
+      "armor_type" AS "armorType",
       "difficulty",
-      "studentId",
+      "student_id" AS "studentId",
       MODE() WITHIN GROUP (ORDER BY "tier") AS "tier"
     FROM "rankings"
-    GROUP BY "raidId", "armorType", "difficulty", "studentId"
+    GROUP BY "raid_id", "armor_type", "difficulty", "student_id"
   `
 }
 
@@ -28,12 +28,12 @@ export const fetchGlobalRankings = async (): Promise<Ranking[]> => {
 export const fetchDataForUser = async (userId: string): Promise<Ranking[]> => {
   return prisma.$queryRaw<Ranking[]>`
     SELECT
-      "raidId",
-      "armorType",
+      "raid_id" AS "raidId",
+      "armor_type" AS "armorType",
       "difficulty",
-      "studentId",
+      "student_id" AS "studentId",
       "tier"
     FROM "rankings"
-    WHERE "userId" = ${userId}
+    WHERE "user_id" = ${userId}
   `
 }

--- a/src/lib/tiers.ts
+++ b/src/lib/tiers.ts
@@ -1,4 +1,4 @@
-import { SquadType } from '@/lib/shaleDbTypes'
+import { ArmorType, Difficulty, SquadType } from '@/lib/shaleDbTypes'
 
 export enum Tier {
   SS = 'SS',
@@ -29,4 +29,24 @@ export const SquadTypes = [
     title: 'Special',
     squadType: SquadType.Support,
   },
+]
+
+export const AllDifficulties: Difficulty[] = [
+  Difficulty.Normal,
+  Difficulty.Hard,
+  Difficulty.VeryHard,
+  Difficulty.Hardcore,
+  Difficulty.Extreme,
+  Difficulty.Insane,
+  Difficulty.Torment,
+  Difficulty.Floor1_49,
+  Difficulty.Floor50_125,
+]
+
+export const AllArmorTypes: ArmorType[] = [
+  ArmorType.Normal,
+  ArmorType.LightArmor,
+  ArmorType.HeavyArmor,
+  ArmorType.Unarmed,
+  ArmorType.ElasticArmor,
 ]


### PR DESCRIPTION
This PR sets up the base ranking retrieval, along with a custom endpoint to query rankings for a specific user.

At the moment I have decided to use MODE() to determine how to sort global rankings. I.e. the most common tier for each user. This should be the least computationally intensive methods, but it also is the most vandalism-proof (fake rankings will be ignored as long as the real ranking has more votes). Proof of the efficacy of this idea remains to be proven. :) 